### PR TITLE
Feature/string match question type

### DIFF
--- a/app/js/app/directives/content_editor.js
+++ b/app/js/app/directives/content_editor.js
@@ -25,6 +25,7 @@ define([
 	"jsx!./react_classes/EventPageBlock",
 	"jsx!./react_classes/ContentBlock",
 	"jsx!./react_classes/ChoiceBlock",
+	"jsx!./react_classes/StringChoiceBlock",
 	"jsx!./react_classes/QuantityChoiceBlock",
 	"jsx!./react_classes/FormulaChoiceBlock",
 	"jsx!./react_classes/ChemicalFormulaChoiceBlock",
@@ -52,6 +53,7 @@ define([
 		_EventPageBlock,
 		_ContentBlock,
 		_ChoiceBlock,
+		_StringChoiceBlock,
 		_QuantityChoiceBlock,
 		_FormulaChoiceBlock,
 		_ChemicalFormulaChoiceBlock,
@@ -169,6 +171,8 @@ define([
 
 	var ChoiceBlock = _ChoiceBlock(ContentEditor, Block, ContentBlock, ContentValueOrChildren);
 
+	var StringChoiceBlock = _StringChoiceBlock(ContentEditor, Block, ContentBlock, ContentValueOrChildren);
+
 	var QuantityChoiceBlock = _QuantityChoiceBlock(ContentEditor, Block, ContentBlock);
 
 	var FormulaChoiceBlock = _FormulaChoiceBlock(ContentEditor, Block, ContentBlock);
@@ -191,6 +195,7 @@ define([
 	typeMap["page"] = ContentBlock;
 	typeMap["isaacPageFragment"] = ContentBlock;
 	typeMap["choice"] = ChoiceBlock;
+	typeMap["stringChoice"] = StringChoiceBlock;
 	typeMap["quantity"] = QuantityChoiceBlock;
 	typeMap["formula"] = FormulaChoiceBlock;
 	typeMap["chemicalFormula"] = ChemicalFormulaChoiceBlock;
@@ -202,6 +207,7 @@ define([
 	typeMap["isaacMultiChoiceQuestion"] = QuestionBlock;
 	typeMap["isaacNumericQuestion"] = QuestionBlock;
 	typeMap["isaacSymbolicQuestion"] = QuestionBlock;
+	typeMap["isaacStringMatchQuestion"] = QuestionBlock;
 	typeMap["isaacSymbolicChemistryQuestion"] = QuestionBlock;
 	typeMap["emailTemplate"] = EmailTemplateBlock;
 

--- a/app/js/app/directives/react_classes/QuestionBlock.js
+++ b/app/js/app/directives/react_classes/QuestionBlock.js
@@ -208,13 +208,15 @@ define(["react", "jquery"], function(React,$) {
 					var requiredChildType = "quantity";
 				} else if (this.props.doc.type == "isaacSymbolicQuestion") {
 					var requiredChildType = "formula";
+				} else if (this.props.doc.type == "isaacStringMatchQuestion") {
+					var requiredChildType = "stringChoice";
 				} else if (this.props.doc.type == "isaacSymbolicChemistryQuestion") {
 					var requiredChildType = "chemicalFormula";
 				} else {
 					var requiredChildType = "choice";
 				}
 
-				if (this.props.doc.type == "isaacMultiChoiceQuestion" || this.props.doc.type == "isaacNumericQuestion" || this.props.doc.type == "isaacSymbolicQuestion" || this.props.doc.type == "isaacSymbolicChemistryQuestion")
+				if (["isaacMultiChoiceQuestion", "isaacNumericQuestion", "isaacSymbolicQuestion", "isaacStringMatchQuestion", "isaacSymbolicChemistryQuestion"].includes(this.props.doc.type))
 					var choices = <Block type="choices" blockTypeTitle="Choices">
 						<ContentChildren items={this.props.doc.choices || []} encoding={this.encoding} onChange={this.onChoicesChange} requiredChildType={requiredChildType}/>
 					</Block>
@@ -294,6 +296,7 @@ define(["react", "jquery"], function(React,$) {
 										<input type="radio" name="question-type" value="isaacMultiChoiceQuestion" checked={this.props.doc.type == "isaacMultiChoiceQuestion"} onChange={this.type_Change} /> Multiple Choice Question<br/>
 										<input type="radio" name="question-type" value="isaacNumericQuestion" checked={this.props.doc.type == "isaacNumericQuestion"} onChange={this.type_Change} /> Numeric Question<br/>
 										<input type="radio" name="question-type" value="isaacSymbolicQuestion" checked={this.props.doc.type == "isaacSymbolicQuestion"} onChange={this.type_Change} /> Symbolic Question<br/>
+										<input type="radio" name="question-type" value="isaacStringMatchQuestion" checked={this.props.doc.type == "isaacStringMatchQuestion"} onChange={this.type_Change} /> String Match Quesiton<br />
 										<input type="radio" name="question-type" value="isaacSymbolicChemistryQuestion" checked={this.props.doc.type == "isaacSymbolicChemistryQuestion"} onChange={this.type_Change} /> Chemistry Question<br/>
 									</div>
 								</div>

--- a/app/js/app/directives/react_classes/StringChoiceBlock.js
+++ b/app/js/app/directives/react_classes/StringChoiceBlock.js
@@ -12,7 +12,6 @@ define(["react", "jquery"], function(React,$) {
 				var newDoc = $.extend({}, oldDoc);
 				newDoc.value = newVal;
 				newDoc.children = newChildren;
-
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
@@ -20,36 +19,29 @@ define(["react", "jquery"], function(React,$) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
 				newDoc.explanation = newVal;
-
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
 			caseInsensitive_toggle: function(e) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
-
 				newDoc.caseInsensitive = !oldDoc.caseInsensitive;
-
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
 			correct_toggle: function(e) {
 				var oldDoc = this.props.doc;
 				var newDoc = $.extend({}, oldDoc);
-
 				newDoc.correct = !oldDoc.correct;
-
 				this.onDocChange(this, oldDoc, newDoc);
 			},
 
 			render: function() {
-
 				var emptyExplanation = {
 					type: "content",
 					children: [],
 					encoding: "markdown"
 				};
-
 				return (
 					<Block type="content" blockTypeTitle={this.props.blockTypeTitle} doc={this.props.doc} onChange={this.onDocChange}>
 						<div className="row">

--- a/app/js/app/directives/react_classes/StringChoiceBlock.js
+++ b/app/js/app/directives/react_classes/StringChoiceBlock.js
@@ -1,0 +1,74 @@
+define(["react", "jquery"], function(React,$) {
+	return function(ContentEditor, Block, ContentBlock, ContentValueOrChildren) {
+		return React.createClass({
+
+			onDocChange: function(c, oldDoc, newDoc) {
+				this.props.onChange(this, oldDoc, newDoc);
+			},
+
+			onContentChange: function(c, oldVal, newVal, oldChildren, newChildren) {
+				// newVal could be a string or a list.
+				var oldDoc = this.props.doc;
+				var newDoc = $.extend({}, oldDoc);
+				newDoc.value = newVal;
+				newDoc.children = newChildren;
+
+				this.onDocChange(this, oldDoc, newDoc);
+			},
+
+			onExplanationChange: function(c, oldVal, newVal) {
+				var oldDoc = this.props.doc;
+				var newDoc = $.extend({}, oldDoc);
+				newDoc.explanation = newVal;
+
+				this.onDocChange(this, oldDoc, newDoc);
+			},
+
+			caseInsensitive_toggle: function(e) {
+				var oldDoc = this.props.doc;
+				var newDoc = $.extend({}, oldDoc);
+
+				newDoc.caseInsensitive = !oldDoc.caseInsensitive;
+
+				this.onDocChange(this, oldDoc, newDoc);
+			},
+
+			correct_toggle: function(e) {
+				var oldDoc = this.props.doc;
+				var newDoc = $.extend({}, oldDoc);
+
+				newDoc.correct = !oldDoc.correct;
+
+				this.onDocChange(this, oldDoc, newDoc);
+			},
+
+			render: function() {
+
+				var emptyExplanation = {
+					type: "content",
+					children: [],
+					encoding: "markdown"
+				};
+
+				return (
+					<Block type="content" blockTypeTitle={this.props.blockTypeTitle} doc={this.props.doc} onChange={this.onDocChange}>
+						<div className="row">
+							<div className="small-1 column text-right">
+								{this.props.doc.correct ?
+									<i style={{color: "#0a0"}} className="correct-mark general foundicon-checkmark" onClick={this.correct_toggle}/> :
+									<i style={{color: "#a00"}} className="correct-mark general foundicon-remove" onClick={this.correct_toggle} />}
+							</div>
+							<div className="small-6 columns" >
+								<ContentValueOrChildren value={this.props.doc.value} children={this.props.doc.children} disableListOps={this.props.disableListOps} encoding={this.props.doc.encoding} onChange={this.onContentChange}/>
+								<input style={{marginTop: "0"}} type="checkbox" checked={this.props.doc.caseInsensitive} onChange={this.caseInsensitive_toggle} /> Case insesnsitive
+							</div>
+							<div className="small-5 columns" >
+								<ContentBlock type="content" blockTypeTitle="Explanation" doc={this.props.doc.explanation || emptyExplanation} onChange={this.onExplanationChange} />
+							</div>
+						</div>
+					</Block>
+				);
+			}
+		})
+	}
+})

--- a/app/snippets/content_templates/stringChoice.json
+++ b/app/snippets/content_templates/stringChoice.json
@@ -1,0 +1,11 @@
+{
+	"encoding": "markdown",
+	"value": "_Enter choice here_",
+	"type": "stringChoice",
+	"caseInsensitive": false,
+	"explanation": {
+		"type": "content",
+		"children": [],
+		"encoding": "markdown"
+	}
+}


### PR DESCRIPTION
This does generate slightly different JSON to the JSON in the example question because my implementation of "StringChoice" matches the explanation structure of a standard "Choice".

Example Question Schema:
```
      "explanation": {
        "type": "content",
        "value": "hello is lowercase!",
        "encoding": "markdown"
      }
```

Implemented Schema:
```
      "explanation": {
        "type": "content",
        "children": [
          {
            "type": "content",
            "value": "hello is lowercase!",
            "encoding": "markdown"
          }
        ],
        "encoding": "markdown"
      }
```

This doesn't make a difference to what is eventually rendered but it matches what other Choice types use.